### PR TITLE
set flowCommentSyntax to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ function getResult(count) {
 ```
 into:
 ```javascript
-/*::
+
 type Result = {
   id: string,
   count: number
 };
-*/
+
 /**
  * @typedef {object} Result
  * @property {string} id
@@ -39,15 +39,10 @@ type Result = {
  * @param {number} count
  * @returns {Result}
  */
-function getResult(count /*: number */) /*: Result */ {
+function getResult(count: number): Result {
 }
 ```
 
-## Benefits
-- No need to transpile but still get the benefits of type checking
-- Compatibility with IDEs such as WebStorm
-  - Currently WebStorm doesn't support [Flow comment syntax](https://flowtype.org/blog/2015/02/20/Flow-Comments.html), so it's either transpile or nothing
-- Benefit from existing JSDoc comments
 
 ## Inspiration
 This is inspired by [flow-jsdoc](https://github.com/Kegsay/flow-jsdoc), but is a totally separate implementation of the same idea. This uses the [Espree](https://github.com/eslint/espree) parser instead and implements some of the things flow-jsdoc is missing.

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "awilix": "4.3.1",
     "commander": "7.0.0",
     "doctrine": "3.0.0",
+    "eslint": "7.18.0",
     "espree": "^4",
     "fs-extra": "9.1.0",
     "lodash": "4.17.20"
   },
   "devDependencies": {
-    "eslint": "7.18.0",
     "mocha": "8.2.1",
     "prettier": "^2.2.1",
     "should": "13.2.3"

--- a/src/flow_annotation.js
+++ b/src/flow_annotation.js
@@ -64,7 +64,7 @@ function determineVarType(varType) {
 }
 
 class FlowAnnotation {
-    constructor({ useFlowCommentSyntax = true } = {}) {
+    constructor({ useFlowCommentSyntax = false } = {}) {
         if (useFlowCommentSyntax) {
             this.inlinePre = ' /*';
             this.inlinePost = ' */';

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ class Converter {
 
     _createContainer(options) {
         const container = createContainer();
-        container.register({ useFlowCommentSyntax: asValue(options.flowCommentSyntax || true) });
+        container.register({ useFlowCommentSyntax: asValue(options.flowCommentSyntax || false) });
         container.loadModules([
             './flow_annotation.js',
             './fixers/*.js',

--- a/test/callback_fixer-tests.js
+++ b/test/callback_fixer-tests.js
@@ -16,9 +16,9 @@ describe('callbackFixer', function() {
             `;
             const modifiedCode = converter.convertSourceCode(code);
             isCodeEqual(modifiedCode, `
-            /*::
+
             type MyCallback = (arg1: number) => void;
-            */
+
             /**
              * @callback MyCallback
              * @param {number} arg1
@@ -38,9 +38,9 @@ describe('callbackFixer', function() {
             `;
             const modifiedCode = converter.convertSourceCode(code);
             isCodeEqual(modifiedCode, `
-            /*::
+
             type MyCallback = (arg1: number) => number;
-            */
+
             /**
              * @callback MyCallback
              * @param {number} arg1

--- a/test/fixtures/annotated/test1.js
+++ b/test/fixtures/annotated/test1.js
@@ -5,9 +5,9 @@ const Promise = require('bluebird');
 
 const file2 = require('./file2.js');
 
-/*::
+
 type fnCallback = () => void;
-*/
+
 /**
  * @callback fnCallback
  */
@@ -16,7 +16,7 @@ type fnCallback = () => void;
  * @param {number} a
  * @param {fnCallback} cb
  */
-function gimmeCallback(a /*: number */, cb /*: fnCallback */) {
+function gimmeCallback(a : number, cb : fnCallback) {
 }
 
 file2.add1(1);
@@ -24,15 +24,15 @@ file2.add1(1);
 /**
  * @returns {Promise<string>}
  */
-function promiseMe() /*: Promise<string> */ {
-    /*::
-    type promiseMeCoroutine = () => void;
-    */
+function promiseMe(): Promise<string> {
+
+        type promiseMeCoroutine = () => void;
+
     /**
      * @callback promiseMeCoroutine
      */
     /** @type {promiseMeCoroutine} */
-    const fn /*: promiseMeCoroutine */ = Promise.coroutine(function*() {
+    const fn : promiseMeCoroutine = Promise.coroutine(function*() {
         return 1;
     });
     return fn();

--- a/test/fixtures/annotated/test2.js
+++ b/test/fixtures/annotated/test2.js
@@ -13,7 +13,7 @@ const e = exports;
  * @param {object=} obj.e
  * @returns {number}
  */
-e.fn1 = ({a, b, c, d, e} /*: { a: string, b: string, c: {}, d?: ?{}, e?: ?{} } */) /*: number */ => {
+e.fn1 = ({a, b, c, d, e}: { a: string, b: string, c: {}, d?: ?{}, e?: ?{} }) : number => {
 };
 
 /**
@@ -27,7 +27,7 @@ e.fn1 = ({a, b, c, d, e} /*: { a: string, b: string, c: {}, d?: ?{}, e?: ?{} } *
  * @param {object=} obj.e
  * @returns {number}
  */
-e.fn2 = ({a, b, c, d, e} /*: { a: string, b: string, c: {}, d?: ?{}, e?: ?{} } */) /*: number */ => {
+e.fn2 = ({a, b, c, d, e}: { a: string, b: string, c: {}, d?: ?{}, e?: ?{} }) : number => {
 };
 
 /**
@@ -40,5 +40,5 @@ e.fn2 = ({a, b, c, d, e} /*: { a: string, b: string, c: {}, d?: ?{}, e?: ?{} } *
  * @param {object=} obj.d
  * @returns {number}
  */
-e.fn3 = ({a, b, c, d} /*: { a: string, b: string, c?: ?{}, d?: ?{} } */) /*: number */ => {
+e.fn3 = ({a, b, c, d} : { a: string, b: string, c?: ?{}, d?: ?{} }) : number => {
 };

--- a/test/param_fixer-tests.js
+++ b/test/param_fixer-tests.js
@@ -40,7 +40,7 @@ describe('paramFixer', function() {
             /**
              * @param {object} obj
              */
-            function test(obj /*: {  } */) {
+            function test(obj : {  }) {
             }
             `);
         });
@@ -60,7 +60,7 @@ describe('paramFixer', function() {
             /**
              * @param {number} a
              */
-            function test(a /*: number */) {
+            function test(a : number) {
             }
             `);
         });
@@ -80,7 +80,7 @@ describe('paramFixer', function() {
             /**
              * @param {number} a
              */
-            Something.prototype.test = function(a /*: number */) {
+            Something.prototype.test = function(a : number) {
             }
             `);
         });
@@ -100,7 +100,7 @@ describe('paramFixer', function() {
             /**
              * @param {number} a
              */
-            const test = function(a /*: number */) {
+            const test = function(a : number) {
             }
             `);
         });
@@ -123,7 +123,7 @@ describe('paramFixer', function() {
                 /**
                  * @param {number} a
                  */
-                foo: function(a /*: number */) {
+                foo: function(a : number) {
                 }
             };
             `);
@@ -144,7 +144,7 @@ describe('paramFixer', function() {
             /**
              * @param {number} a
              */
-            const test = (a /*: number */) => {
+            const test = (a : number) => {
             };
             `);
         });
@@ -168,7 +168,7 @@ describe('paramFixer', function() {
              * @param {number} obj.a
              * @param {number} obj.b
              */
-            e.test = ({ a, b } /*: { a: number, b: number } */) => {
+            e.test = ({ a, b } : { a: number, b: number }) => {
             };
             `);
         });
@@ -188,7 +188,7 @@ describe('paramFixer', function() {
             /**
              * @param {number} a
              */
-            const test = a /*: number */ => {
+            const test = (a : number) => {
             };
             `);
         });
@@ -211,7 +211,7 @@ describe('paramFixer', function() {
                 /**
                  * @param {number} a
                  */
-                test(a /*: number */) {
+                test(a : number) {
                 }
             }
             `);
@@ -234,7 +234,7 @@ describe('paramFixer', function() {
              * @param {object} obj
              * @param {number=} obj.a
              */
-            function test({ a = 1 } /*: { a?: number } */) {
+            function test({ a = 1 } : { a?: number } ) {
             }
             `);
         });
@@ -254,7 +254,7 @@ describe('paramFixer', function() {
             /**
              * @param {number} [a=1]
              */
-            function test(a /*: number */) {
+            function test(a : number) {
             }
             `);
         });
@@ -274,7 +274,7 @@ describe('paramFixer', function() {
             /**
              * @param {number=} a
              */
-            function test(a /*: ?number */) {
+            function test(a: ?number) {
             }
             `);
         });
@@ -314,7 +314,7 @@ describe('paramFixer', function() {
             /**
              * @param {*} a
              */
-            function test(a /*: any */) {
+            function test(a : any) {
             }
             `);
         });
@@ -334,7 +334,7 @@ describe('paramFixer', function() {
             /**
              * @param {number|boolean} a
              */
-            function test(a /*: number | boolean */) {
+            function test(a: number | boolean) {
             }
             `);
         });
@@ -354,7 +354,7 @@ describe('paramFixer', function() {
             /**
              * @param {number} a
              */
-            function test(a /*: number */ = 1) {
+            function test(a : number = 1) {
             }
             `);
         });
@@ -376,7 +376,47 @@ describe('paramFixer', function() {
              * @param {object} obj
              * @param {number} obj.a
              */
-            function test({ a } /*: { a: number } */) {
+            function test({ a } : { a: number } ) {
+            }
+            `);
+        });
+
+        it('should work', function() {
+            const code = `
+            /**
+             * @param {object} obj
+             * @param {number=} obj.a
+             */
+            function test({ a }) {
+            }
+            `;
+            const modifiedCode = converter.convertSourceCode(code);
+            isCodeEqual(modifiedCode, `
+            /**
+             * @param {object} obj
+             * @param {number=} obj.a
+             */
+            function test({ a } : { a?: ?number } ) {
+            }
+            `);
+        });
+
+        it('should work', function() {
+            const code = `
+            /**
+             * @param {object} obj
+             * @param {number} obj.a
+             */
+            function test({ a } = {a: 1}) {
+            }
+            `;
+            const modifiedCode = converter.convertSourceCode(code);
+            isCodeEqual(modifiedCode, `
+            /**
+             * @param {object} obj
+             * @param {number} obj.a
+             */
+            function test({ a } : { a: number } = {a: 1}) {
             }
             `);
         });
@@ -406,7 +446,7 @@ describe('paramFixer', function() {
              * @param {number} obj.d.e
              * @param {string} f
              */
-            function test(a /*: number */, obj /*: { c: number, d: { e: number } } */, f /*: string */) {
+            function test(a : number, obj : { c: number, d: { e: number } } , f : string ) {
             }
             `);
         });
@@ -436,7 +476,7 @@ describe('paramFixer', function() {
              * @param {number=} obj.d.e
              * @param {string} f
              */
-            function test(a /*: number */, obj /*: { c?: ?number, d?: { e?: ?number } } */, f /*: string */) {
+            function test(a : number, obj : { c?: ?number, d?: { e?: ?number } } , f : string ) {
             }
             `);
         });
@@ -468,7 +508,7 @@ describe('paramFixer', function() {
              * @param {object} obj2.d
              * @param {number} obj2.d.e
              */
-            function test(a /*: number */, { b } /*: { b: number } */, { c, d: { e } } /*: { c: number, d: { e: number } } */) {
+            function test(a : number, { b } : { b: number } , { c, d: { e } } : { c: number, d: { e: number } } ) {
             }
             `);
         });
@@ -490,7 +530,7 @@ describe('paramFixer', function() {
              * @param {object} obj
              * @param {number} obj.a
              */
-            function test({ a = 1 } /*: { a: number } */) {
+            function test({ a = 1 } : { a: number } ) {
             }
             `);
         });
@@ -514,7 +554,7 @@ describe('paramFixer', function() {
              * @param {object} obj1.a
              * @param {number} obj1.a.b
              */
-            function test({ a: { b } } /*: { a: { b: number } } */) {
+            function test({ a: { b } } : { a: { b: number } } ) {
             }
             `);
         });
@@ -538,7 +578,7 @@ describe('paramFixer', function() {
              * @param {object} obj1.a
              * @param {number} obj1.a.b
              */
-            function test({ a: { b = 1 } } /*: { a: { b: number } } */) {
+            function test({ a: { b = 1 } } : { a: { b: number } } ) {
             }
             `);
         });
@@ -558,7 +598,7 @@ describe('paramFixer', function() {
             /**
              * @param {number[]} a
              */
-            function test(a /*: Array<number> */) {
+            function test(a : Array<number> ) {
             }
             `);
         });
@@ -580,7 +620,7 @@ describe('paramFixer', function() {
              * @param {object[]} obj
              * @param {number} obj[].a
              */
-            function test(obj /*: Array<{}> */) {
+            function test(obj : Array<{}> ) {
             }
             `);
         });
@@ -600,7 +640,7 @@ describe('paramFixer', function() {
             /**
              * @param {number} theArgs
              */
-            function test(...theArgs /*: Array<number> */) {
+            function test(...theArgs : Array<number> ) {
             }
             `);
         });

--- a/test/property_fixer-tests.js
+++ b/test/property_fixer-tests.js
@@ -21,9 +21,9 @@ describe('propertyFixer', function() {
              * @property {number} count
              */
             class Test {
-            /*::
+
             count: number;
-            */
+
             }
             `);
         });
@@ -46,9 +46,9 @@ describe('propertyFixer', function() {
              */
             class Test
             {
-            /*::
+
             count: number;
-            */
+
             }
             `);
         });
@@ -71,10 +71,10 @@ describe('propertyFixer', function() {
              * @property {number} prop2
              */
             class Test {
-            /*::
+
             prop1: number;
             prop2: number;
-            */
+
             }
             `);
         });

--- a/test/returns_fixer-tests.js
+++ b/test/returns_fixer-tests.js
@@ -20,7 +20,7 @@ describe('returnsFixer', function() {
             /**
              * @returns {number}
              */
-            function test() /*: number */ {
+            function test() : number {
             }
             `);
         });
@@ -41,7 +41,7 @@ describe('returnsFixer', function() {
             /**
              * @returns {number}
              */
-            function test() /*: number */
+            function test() : number
             {
             }
             `);
@@ -66,7 +66,7 @@ describe('returnsFixer', function() {
              */
             function test(
                 a, b, c
-            ) /*: number */ {
+            ) : number {
             }
             `);
         });
@@ -89,7 +89,7 @@ describe('returnsFixer', function() {
                 /**
                  * @returns {number}
                  */
-                test() /*: number */ {
+                test() : number {
                 }
             }
             `);
@@ -110,7 +110,7 @@ describe('returnsFixer', function() {
             /**
              * @returns {number}
              */
-            Something.prototype.test = () /*: number */ => {
+            Something.prototype.test = () : number => {
             }
             `);
         });
@@ -130,7 +130,7 @@ describe('returnsFixer', function() {
             /**
              * @returns {number}
              */
-            Something.prototype.test = function() /*: number */ {
+            Something.prototype.test = function() : number {
             }
             `);
         });
@@ -150,7 +150,7 @@ describe('returnsFixer', function() {
             /**
              * @returns {number}
              */
-            const test = function() /*: number */ {
+            const test = function() : number {
             }
             `);
         });
@@ -173,7 +173,7 @@ describe('returnsFixer', function() {
                 /**
                  * @returns {number}
                  */
-                foo: function() /*: number */ {
+                foo: function() : number {
                 }
             };
             `);
@@ -194,7 +194,7 @@ describe('returnsFixer', function() {
             /**
              * @returns {number}
              */
-            const test = (a) /*: number */ => {
+            const test = (a) : number => {
             };
             `);
         });
@@ -234,7 +234,7 @@ describe('returnsFixer', function() {
             /**
              * @returns {Promise<number>}
              */
-            function test() /*: Promise<number> */ {
+            function test() : Promise<number>  {
             };
             `);
         });

--- a/test/returns_fixer-tests.js
+++ b/test/returns_fixer-tests.js
@@ -201,7 +201,7 @@ describe('returnsFixer', function() {
     });
 
     describe('return type for arrow function without brackets', function() {
-        it('should work but does not change anything', function() {
+        it('should work', function() {
             const code = `
             /**
              * @returns {number}
@@ -214,7 +214,7 @@ describe('returnsFixer', function() {
             /**
              * @returns {number}
              */
-            const test = a => {
+            const test = (a): number => {
             };
             `);
         });

--- a/test/type_fixer-tests.js
+++ b/test/type_fixer-tests.js
@@ -15,7 +15,7 @@ describe('typeFixer', function() {
             const modifiedCode = converter.convertSourceCode(code);
             isCodeEqual(modifiedCode, `
             /** @type {number} */
-            const count /*: number */ = 1;
+            const count : number = 1;
             `);
         });
     });
@@ -31,7 +31,7 @@ describe('typeFixer', function() {
             isCodeEqual(modifiedCode, `
             const var1 = 2;
             /** @type {number} */
-            const count /*: number */ = 1;
+            const count : number = 1;
             `);
         });
     });

--- a/test/typedef_fixer-tests.js
+++ b/test/typedef_fixer-tests.js
@@ -15,9 +15,9 @@ describe('typedefFixer', function() {
             `;
             const modifiedCode = converter.convertSourceCode(code);
             isCodeEqual(modifiedCode, `
-            /*::
+
             type MyNumber = number;
-            */
+
             /**
              * @typedef {number} MyNumber
              */
@@ -34,9 +34,9 @@ describe('typedefFixer', function() {
             `;
             const modifiedCode = converter.convertSourceCode(code);
             isCodeEqual(modifiedCode, `
-            /*::
+
             type MyUnion = number | boolean;
-            */
+
             /**
              * @typedef {number|boolean} MyUnion
              */
@@ -55,12 +55,12 @@ describe('typedefFixer', function() {
             `;
             const modifiedCode = converter.convertSourceCode(code);
             isCodeEqual(modifiedCode, `
-            /*::
+
             type MyObject = {
               prop1: boolean,
               prop2: boolean
             };
-            */
+
             /**
              * @typedef {object} MyObject
              * @property {boolean} prop1


### PR DESCRIPTION
This uses the default `: type` annotation for flow or typescript instead of the comment syntax.